### PR TITLE
Use body for error message from signup API

### DIFF
--- a/next-drizzle-authjs/src/app/api/signup/route.ts
+++ b/next-drizzle-authjs/src/app/api/signup/route.ts
@@ -21,7 +21,6 @@ export async function POST(request: Request): Promise<Response> {
   ) {
     return new Response(JSON.stringify({ message: "Invalid password" }), {
       status: 400,
-      statusText: "Invalid password",
     });
   }
 
@@ -35,7 +34,6 @@ export async function POST(request: Request): Promise<Response> {
       JSON.stringify({ message: "An account with this email already exists" }),
       {
         status: 400,
-        statusText: "An account with this email already exists",
       },
     );
   }

--- a/next-drizzle-authjs/src/app/api/signup/route.ts
+++ b/next-drizzle-authjs/src/app/api/signup/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: Request): Promise<Response> {
     typeof email !== "string" ||
     typeof name !== "string"
   ) {
-    return new Response(null, {
+    return new Response(JSON.stringify({ message: "Invalid password" }), {
       status: 400,
       statusText: "Invalid password",
     });
@@ -31,10 +31,13 @@ export async function POST(request: Request): Promise<Response> {
     .where(eq(schema.users.email, email));
 
   if (emailExists.length > 0) {
-    return new Response(null, {
-      status: 400,
-      statusText: "An account with this email already exists",
-    });
+    return new Response(
+      JSON.stringify({ message: "An account with this email already exists" }),
+      {
+        status: 400,
+        statusText: "An account with this email already exists",
+      },
+    );
   }
 
   const userId = v4();

--- a/next-drizzle-authjs/src/app/signup/page.tsx
+++ b/next-drizzle-authjs/src/app/signup/page.tsx
@@ -17,13 +17,14 @@ export default function SignUpPage() {
           className="flex flex-col gap-3"
           action={async (formData) => {
             try {
-              const res = await fetch("/api/signup", {
+              const response = await fetch("/api/signup", {
                 method: "POST",
                 body: formData,
               });
 
-              if (!res.ok) {
-                throw new Error(res.statusText);
+              if (!response.ok) {
+                const responseBody = await response.json();
+                throw new Error(responseBody.message || "Unknown error");
               }
 
               router.push("/");


### PR DESCRIPTION
The `statusText` was not working properly on Cloudflare Pages nor Vercel.

Using the body is generally better anyway for error messages.